### PR TITLE
Split release into pack + publish so the tag targets the build commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,8 @@ jobs:
         if: steps.skip.outputs.skip != 'true'
         run: python -m tools.build_geojson
 
-      - name: Publish release
+      - name: Pack archive and update README
         if: steps.skip.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python -m tools.release \
             --description-file /tmp/desc.md \
@@ -116,3 +114,10 @@ jobs:
           )
           git commit -m "CI: release ${tag} [skip release][skip ci]"
           git push origin HEAD:main
+
+      - name: Publish GitHub Release
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python -m tools.publish

--- a/README.md
+++ b/README.md
@@ -188,11 +188,23 @@ Escape hatches:
 
 -   **Suppress release for a trivial change** (e.g. typo fix in a metadata file): include `[skip release]` in the merge commit message. CI will skip the release step.
 -   **Force a release without a data change** (e.g. after fixing `tools/build_geojson.py`): go to the Actions tab → "Release on data merge" → "Run workflow", and supply a description via the manual input.
--   **Emergency local release** (CI is down): pull `main`, ensure `build/` is current (`python -m tools.build_geojson`), then run `python -m tools.release` interactively. Commit + push `build/`, `qa/`, `README.md` manually.
+-   **Emergency local release** (CI is down): pull `main`, then run the same sequence the CI workflow runs:
+
+    ```
+    .venv/bin/python -m tools.qa
+    .venv/bin/python -m tools.build_geojson
+    .venv/bin/python -m tools.release                   # interactive; packs dist/<tag>.tar.gz + updates README
+    git add build/ qa/qa_log.csv qa/matrix_log.csv qa/reports/ README.md
+    git commit -m "New build YYYY-MM-DD"
+    git push
+    .venv/bin/python -m tools.publish                   # creates the GitHub Release pointing at HEAD
+    ```
+
+    The publish step is separate from the pack step so the GitHub Release tag points at the commit that contains the build artifacts (the push above), not the pre-build merge commit.
 
 Maintainers who will cut emergency local releases also need:
 
--   `gh` CLI installed and authenticated (`gh auth login`).
+-   `gh` CLI installed and authenticated (`gh auth login`) — required by `tools.publish`, not by `tools.release`.
 -   `$EDITOR` set (used by `tools.release` for the interactive description prompt).
 
 # Release internals
@@ -205,8 +217,9 @@ What it does, in order:
 2.  Extracts the `## What's new` section from the merge commit's PR body (via `gh api`).
 3.  Runs `python -m tools.qa`.
 4.  Runs `python -m tools.build_geojson`.
-5.  Runs `python -m tools.release --description-file <tmp> --non-interactive`, which packs `build/` as a `dist/<tag>.tar.gz` archive, publishes a GitHub Release tagged `build-YYYY-MM-DD-<sha>`, and updates the README.
+5.  Runs `python -m tools.release --description-file <tmp> --non-interactive`, which packs `build/` as `dist/<tag>.tar.gz`, persists the description as `dist/<tag>.description.md`, and updates the README. This step does NOT publish anything.
 6.  Commits and pushes the resulting `build/`, `qa/`, and `README.md` back to `main` with `[skip release][skip ci]` in the commit message to prevent recursive triggering.
+7.  Runs `python -m tools.publish`, which calls `gh release create <tag> dist/<tag>.tar.gz --target $(git rev-parse HEAD) ...`. Because this runs *after* the commit-back, the release tag points at the commit that contains the build artifacts in its tree — not at the pre-build merge commit. The release URL is determined by `<tag>` and matches what `tools.release` wrote into the README in step 5.
 
 The pre-existing `qa.yml` workflow runs `pytest` + `tools.qa` on PRs as the merge gate; it does not trigger on `build/`, `qa/`, or `README.md` changes, so the release workflow's commit-back does not retrigger it.
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,135 @@
+"""Integration tests for `tools.publish` — the GitHub Release step that runs
+after the build commit has been pushed to main.
+"""
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _seed_packed(tmp: Path, *, tag: str = "build-2026-05-22-newsha1", with_archive: bool = True, with_description: bool = True) -> None:
+    (tmp / "build").mkdir()
+    (tmp / "build" / "manifest.json").write_text(json.dumps({
+        "shapefile": "data/shapefiles/DRC_Health_zones.shp",
+        "built_at": "2026-05-22T10:00:00+00:00",
+        "commit": "newsha1",
+        "datasets": [],
+    }))
+    (tmp / "dist").mkdir()
+    if with_archive:
+        (tmp / "dist" / f"{tag}.tar.gz").write_bytes(b"fake-archive")
+    if with_description:
+        (tmp / "dist" / f"{tag}.description.md").write_text("Release notes.\n")
+
+
+def _init_git(tmp: Path, head_sha: str = "deadbeef") -> str:
+    subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=tmp,
+        check=True,
+    )
+    sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=tmp, text=True).strip()
+    return sha
+
+
+def _install_gh_stub(tmp: Path, *, returncode: int = 0) -> tuple[Path, Path]:
+    bin_dir = tmp / "bin"
+    bin_dir.mkdir()
+    gh_log = tmp / "gh.log"
+    body = (
+        f"""#!/usr/bin/env bash
+echo "$@" >> {gh_log}
+if [ "$1" = "release" ] && [ "$2" = "create" ]; then
+  echo "https://github.com/INRB-UMIE/Ebola_DRC_2026/releases/tag/$3"
+fi
+exit {returncode}
+"""
+    )
+    _make_stub(bin_dir / "gh", body)
+    return bin_dir, gh_log
+
+
+def _env(tmp: Path, bin_dir: Path) -> dict:
+    return {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        "PYTHONPATH": str(REPO_ROOT),
+    }
+
+
+def _run(tmp: Path, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "tools.publish"],
+        cwd=tmp,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_publishes_with_head_as_target(tmp_path):
+    _seed_packed(tmp_path)
+    sha = _init_git(tmp_path)
+    bin_dir, gh_log = _install_gh_stub(tmp_path)
+    result = _run(tmp_path, _env(tmp_path, bin_dir))
+    assert result.returncode == 0, result.stderr
+
+    invocations = gh_log.read_text()
+    assert "release create build-2026-05-22-newsha1" in invocations
+    assert f"--target {sha}" in invocations
+    assert "dist/build-2026-05-22-newsha1.tar.gz" in invocations
+    assert "dist/build-2026-05-22-newsha1.description.md" in invocations
+
+
+def test_fails_when_archive_missing(tmp_path):
+    _seed_packed(tmp_path, with_archive=False)
+    _init_git(tmp_path)
+    bin_dir, _ = _install_gh_stub(tmp_path)
+    result = _run(tmp_path, _env(tmp_path, bin_dir))
+    assert result.returncode != 0
+    assert "archive" in result.stderr.lower()
+
+
+def test_fails_when_description_missing(tmp_path):
+    _seed_packed(tmp_path, with_description=False)
+    _init_git(tmp_path)
+    bin_dir, _ = _install_gh_stub(tmp_path)
+    result = _run(tmp_path, _env(tmp_path, bin_dir))
+    assert result.returncode != 0
+    assert "description" in result.stderr.lower()
+
+
+def test_fails_when_gh_missing(tmp_path):
+    _seed_packed(tmp_path)
+    _init_git(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "tools.publish"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/nonexistent-bin", "PYTHONPATH": str(REPO_ROOT), "HOME": str(tmp_path)},
+    )
+    assert result.returncode != 0
+    assert "gh" in result.stderr.lower()
+
+
+def test_propagates_gh_failure(tmp_path):
+    _seed_packed(tmp_path)
+    _init_git(tmp_path)
+    bin_dir, _ = _install_gh_stub(tmp_path, returncode=1)
+    result = _run(tmp_path, _env(tmp_path, bin_dir))
+    assert result.returncode != 0
+    assert "gh release create" in result.stderr.lower() or "failed" in result.stderr.lower()

--- a/tests/test_release_orchestrator.py
+++ b/tests/test_release_orchestrator.py
@@ -1,8 +1,8 @@
 """Integration tests for the tools.release orchestrator (new flow).
 
-Stubs `gh` (PATH manipulation) and `$EDITOR` (env var). The orchestrator no
-longer rebuilds — the workflow does that before calling tools.release — so
-tests do not fake tools.build_geojson.
+Stubs `$EDITOR` (env var). The orchestrator no longer rebuilds and no longer
+publishes — it packs `dist/<tag>.tar.gz`, persists the description alongside,
+and updates README. Publication is `tools.publish`'s job (tested separately).
 """
 
 import json
@@ -71,23 +71,12 @@ def _init_git(tmp: Path) -> None:
     )
 
 
-def _install_stubs(tmp: Path, *, editor_body: str = "", gh_body: str | None = None) -> tuple[Path, Path]:
+def _install_stubs(tmp: Path, *, editor_body: str = "") -> Path:
     bin_dir = tmp / "bin"
     bin_dir.mkdir()
-    gh_log = tmp / "gh.log"
-    default_gh = (
-        f"""#!/usr/bin/env bash
-echo "$@" >> {gh_log}
-if [ "$1" = "release" ] && [ "$2" = "create" ]; then
-  echo "https://github.com/example/repo/releases/tag/$3"
-fi
-exit 0
-"""
-    )
-    _make_stub(bin_dir / "gh", gh_body or default_gh)
     if editor_body:
         _make_stub(bin_dir / "fake-editor", editor_body)
-    return bin_dir, gh_log
+    return bin_dir
 
 
 def _env(tmp: Path, bin_dir: Path, *, editor: Path | None = None) -> dict:
@@ -116,7 +105,7 @@ def _run(tmp: Path, env: dict, *extra_args: str) -> subprocess.CompletedProcess:
 def test_preflight_fails_when_qa_log_missing(tmp_path):
     _seed_repo(tmp_path)
     (tmp_path / "qa" / "qa_log.csv").unlink()
-    bin_dir, _ = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     result = _run(tmp_path, _env(tmp_path, bin_dir))
     assert result.returncode != 0
     assert "qa" in result.stderr.lower()
@@ -127,29 +116,16 @@ def test_preflight_fails_when_qa_log_has_failures(tmp_path):
     (tmp_path / "qa" / "qa_log.csv").write_text(
         "dataset,type,file,status\nfoo,vector,foo.csv,fail\n"
     )
-    bin_dir, _ = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     result = _run(tmp_path, _env(tmp_path, bin_dir))
     assert result.returncode != 0
     assert "fail" in result.stderr.lower()
 
 
-def test_preflight_fails_when_gh_missing(tmp_path):
-    _seed_repo(tmp_path)
-    result = subprocess.run(
-        [sys.executable, "-m", "tools.release"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env={"PATH": "/nonexistent-bin", "PYTHONPATH": str(REPO_ROOT), "HOME": str(tmp_path)},
-    )
-    assert result.returncode != 0
-    assert "gh" in result.stderr.lower()
-
-
 def test_preflight_fails_on_unrelated_dirty_paths(tmp_path):
     _seed_repo(tmp_path)
     _init_git(tmp_path)
-    bin_dir, _ = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     (tmp_path / "unrelated.txt").write_text("dirty")
     result = _run(tmp_path, _env(tmp_path, bin_dir))
     assert result.returncode != 0
@@ -159,7 +135,7 @@ def test_preflight_fails_on_unrelated_dirty_paths(tmp_path):
 # ---------- happy paths ----------
 
 def test_interactive_editor_release(tmp_path):
-    """$EDITOR mode (no flags): full pass publishes current build."""
+    """$EDITOR mode: packs archive, persists description, updates README. Does NOT publish."""
     _seed_repo(tmp_path)
     _init_git(tmp_path)
     editor_body = (
@@ -169,7 +145,7 @@ def test_interactive_editor_release(tmp_path):
         "Updated cross-border POE counts.\n"
         "EOF\n"
     )
-    bin_dir, gh_log = _install_stubs(tmp_path, editor_body=editor_body)
+    bin_dir = _install_stubs(tmp_path, editor_body=editor_body)
     result = _run(tmp_path, _env(tmp_path, bin_dir, editor=bin_dir / "fake-editor"))
     assert result.returncode == 0, result.stderr
 
@@ -182,12 +158,14 @@ def test_interactive_editor_release(tmp_path):
     assert "build/manifest.json" in names
     assert "qa/qa_log.csv" in names
 
-    gh_invocations = gh_log.read_text()
-    assert f"release create {expected_tag}" in gh_invocations
+    description_path = tmp_path / "dist" / f"{expected_tag}.description.md"
+    assert description_path.exists()
+    assert "Updated cross-border POE counts." in description_path.read_text()
 
     readme = (tmp_path / "README.md").read_text()
     assert expected_tag in readme
     assert "Updated cross-border POE counts." in readme
+    assert f"https://github.com/INRB-UMIE/Ebola_DRC_2026/releases/tag/{expected_tag}" in readme
 
     assert not (tmp_path / "build" / "DESCRIPTION.md").exists()
 
@@ -196,7 +174,7 @@ def test_description_file_release(tmp_path):
     """--description-file path: read description from a file, do not open $EDITOR."""
     _seed_repo(tmp_path)
     _init_git(tmp_path)
-    bin_dir, gh_log = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     desc = tmp_path / "desc.md"
     desc.write_text("Refreshed Flowminder month.\n")
     result = _run(
@@ -208,12 +186,14 @@ def test_description_file_release(tmp_path):
     readme = (tmp_path / "README.md").read_text()
     assert "Refreshed Flowminder month." in readme
     assert "build-2026-05-22-newsha1" in readme
+    description_path = tmp_path / "dist" / "build-2026-05-22-newsha1.description.md"
+    assert description_path.exists()
 
 
 def test_non_interactive_without_description_file_fails(tmp_path):
     _seed_repo(tmp_path)
     _init_git(tmp_path)
-    bin_dir, _ = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     result = _run(tmp_path, _env(tmp_path, bin_dir), "--non-interactive")
     assert result.returncode != 0
     assert "description-file" in result.stderr.lower() or "non-interactive" in result.stderr.lower()
@@ -222,7 +202,7 @@ def test_non_interactive_without_description_file_fails(tmp_path):
 def test_description_file_empty_fails(tmp_path):
     _seed_repo(tmp_path)
     _init_git(tmp_path)
-    bin_dir, _ = _install_stubs(tmp_path)
+    bin_dir = _install_stubs(tmp_path)
     desc = tmp_path / "desc.md"
     desc.write_text("   \n\n")
     result = _run(

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -1,0 +1,92 @@
+"""`python -m tools.publish` — publish the packed archive in dist/ as a GitHub
+Release, targeting the current HEAD.
+
+Run AFTER `tools.release` has packed the archive AND AFTER the build commit has
+been pushed to main. Uses `git rev-parse HEAD` as the release `--target` so the
+tag points to the commit that actually contains the build artifacts (not the
+pre-build merge commit).
+
+Reads the tag from `build/manifest.json`, the archive from
+`dist/<tag>.tar.gz`, and the description from `dist/<tag>.description.md`.
+
+Run from repo root:
+    python -m tools.publish
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.lib.release import build_tag
+
+
+REPO_ROOT = Path.cwd()
+BUILD_DIR = REPO_ROOT / "build"
+MANIFEST = BUILD_DIR / "manifest.json"
+DIST_DIR = REPO_ROOT / "dist"
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def main() -> int:
+    if shutil.which("gh") is None:
+        _eprint("gh CLI not found. Install from https://cli.github.com/ and run `gh auth login`.")
+        return 2
+
+    if not MANIFEST.exists():
+        _eprint(f"manifest not found at {MANIFEST}; run `python -m tools.build_geojson` first.")
+        return 2
+
+    manifest = json.loads(MANIFEST.read_text())
+    tag = build_tag(manifest["built_at"], manifest["commit"])
+
+    archive = DIST_DIR / f"{tag}.tar.gz"
+    description = DIST_DIR / f"{tag}.description.md"
+    if not archive.exists():
+        _eprint(f"archive not found: {archive}; run `python -m tools.release` first.")
+        return 2
+    if not description.exists():
+        _eprint(f"description not found: {description}; run `python -m tools.release` first.")
+        return 2
+
+    try:
+        target = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(REPO_ROOT),
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        _eprint("could not resolve HEAD via git; aborting.")
+        return 2
+
+    result = subprocess.run(
+        [
+            "gh", "release", "create", tag,
+            str(archive),
+            "--target", target,
+            "--title", tag,
+            "--notes-file", str(description),
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        _eprint(f"`gh release create` failed:\n{result.stderr}")
+        return 2
+
+    url_lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    url = url_lines[-1] if url_lines else ""
+    _eprint(f"✓ Published {tag} → {url}")
+    _eprint(f"  target: {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,11 +1,17 @@
-"""`python -m tools.release` — package the current build/ as a GitHub Release
-and update README.
+"""`python -m tools.release` — pack the current build/ as a release archive and
+update README.
 
 In the new flow:
 - The release workflow runs `tools.build_geojson` immediately before invoking
   this script, so `build/` already reflects the data on `main`.
-- This script does NOT rebuild and does NOT archive a "previous" build — it
-  publishes whatever is currently in build/ as a new release.
+- This script does NOT rebuild and does NOT publish a GitHub Release. It only
+  packs `dist/<tag>.tar.gz`, writes the description to `dist/<tag>.description.md`,
+  and updates README with the (deterministic) release URL.
+- After this script runs, the caller commits + pushes the build/qa/README
+  changes, then publishes the release via `python -m tools.publish` (or `gh
+  release create ... --target <sha>` directly). Splitting the publish from the
+  pack lets the release tag point to the commit that contains the build
+  artifacts, not the pre-build merge commit.
 - Use `--description-file <path>` to provide the release notes non-interactively
   (CI mode). Otherwise the script opens $EDITOR.
 
@@ -22,13 +28,13 @@ import argparse
 import csv
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
 from tools.lib.release import (
+    DEFAULT_GITHUB_REPO,
     build_tag,
     format_last_build_line,
     pack_archive,
@@ -72,18 +78,14 @@ def _preflight(description_file: str | None = None) -> int:
                     "`python -m tools.qa` before releasing."
                 )
                 return 2
-    if shutil.which("gh") is None:
-        _eprint("gh CLI not found. Install from https://cli.github.com/ and run `gh auth login`.")
-        return 2
     dirty = _git_dirty_paths()
-    # Build effective allowlist: static prefixes plus the description file (if given).
     allowlist = ALLOWLIST_PREFIXES
     if description_file:
         try:
             rel = str(Path(description_file).resolve().relative_to(REPO_ROOT.resolve()))
             allowlist = ALLOWLIST_PREFIXES + (rel,)
         except ValueError:
-            pass  # description file outside repo root — not in dirty list anyway
+            pass
     unrelated = [p for p in dirty if not any(p.startswith(pre) for pre in allowlist)]
     if unrelated:
         _eprint(
@@ -139,8 +141,17 @@ def _resolve_description(args: argparse.Namespace) -> str:
     return body
 
 
-def _publish_current_build(description: str) -> tuple[str, str]:
-    """Pack build/ and create a GitHub Release. Returns (tag, release_url)."""
+def release_url(tag: str, github_repo: str = DEFAULT_GITHUB_REPO) -> str:
+    return f"https://github.com/{github_repo}/releases/tag/{tag}"
+
+
+def _pack_archive(description: str) -> tuple[str, str]:
+    """Pack build/ to dist/<tag>.tar.gz and persist the description alongside it.
+
+    Returns (tag, url). The URL is the deterministic GitHub Release URL — the
+    release itself is published later by `tools.publish` once the build commit
+    has been pushed.
+    """
     manifest = json.loads(MANIFEST.read_text())
     tag = build_tag(manifest["built_at"], manifest["commit"])
 
@@ -154,30 +165,12 @@ def _publish_current_build(description: str) -> tuple[str, str]:
     ]
     pack_archive(members, out_path)
 
-    notes_file: Path
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
-        f.write(description)
-        notes_file = Path(f.name)
-    try:
-        create = subprocess.run(
-            [
-                "gh", "release", "create", tag,
-                str(out_path),
-                "--title", tag,
-                "--notes-file", str(notes_file),
-            ],
-            capture_output=True,
-            text=True,
-            cwd=str(REPO_ROOT),
-        )
-    finally:
-        notes_file.unlink(missing_ok=True)
-    if create.returncode != 0:
-        _eprint(f"`gh release create` failed:\n{create.stderr}")
-        sys.exit(2)
-    url_lines = [ln for ln in create.stdout.strip().splitlines() if ln.strip()]
-    url = url_lines[-1] if url_lines else ""
-    _eprint(f"✓ Published {tag} → {url}")
+    description_path = DIST_DIR / f"{tag}.description.md"
+    description_path.write_text(description, encoding="utf-8")
+
+    url = release_url(tag)
+    _eprint(f"✓ Packed {out_path}")
+    _eprint(f"✓ Wrote {description_path}")
     return tag, url
 
 
@@ -239,7 +232,7 @@ def main() -> int:
         return rc
 
     description = _resolve_description(args)
-    tag, url = _publish_current_build(description)
+    tag, url = _pack_archive(description)
     _update_readme(tag, url, description)
 
     _eprint("")
@@ -247,6 +240,7 @@ def main() -> int:
     _eprint("  git add build/ qa/qa_log.csv qa/matrix_log.csv qa/reports/ README.md")
     _eprint("  git commit -m \"New build YYYY-MM-DD\"")
     _eprint("  git push")
+    _eprint("  python -m tools.publish   # creates the GitHub Release pointing at the build commit")
     return 0
 
 


### PR DESCRIPTION
## What's new

Splits `tools.release` into a pack step and a separate publish step (new `tools.publish`) so that the GitHub Release tag points at the CI commit that contains `build/` in its tree, not the pre-build merge commit.

## Why

In #26's auto-build flow, `tools.release` called `gh release create` *before* the build commit was pushed back to `main`. `gh release create` defaults to tagging current HEAD, so the tag ended up pointing at the user-merge commit — which doesn't contain `build/` because CI builds post-merge. The historical `tools.release` predates the auto-build flow: when contributors used to commit `build/` themselves, HEAD already contained the artifacts when `tools.release` ran. The CI flow changed who builds and when, but the script kept the old "pack + publish in one shot" structure, creating the mismatch.

## What changed

- `tools/release.py` no longer calls `gh release create`. It packs `dist/<tag>.tar.gz`, persists the description to `dist/<tag>.description.md`, and updates the README with a deterministic release URL (`https://github.com/INRB-UMIE/Ebola_DRC_2026/releases/tag/<tag>`).
- New `tools/publish.py`: reads the manifest to derive the tag, finds the archive + description in `dist/`, calls `gh release create <tag> dist/<tag>.tar.gz --target $(git rev-parse HEAD) --title <tag> --notes-file dist/<tag>.description.md`.
- `.github/workflows/release.yml`: renamed "Publish release" to "Pack archive and update README"; added a new "Publish GitHub Release" step that runs `python -m tools.publish` **after** the commit-back. Because that step runs after the commit-back, HEAD is the CI commit, and `--target HEAD` points at the commit containing `build/`.
- `tests/test_release_orchestrator.py`: updated to reflect that `tools.release` no longer calls `gh` and now writes `dist/<tag>.description.md`. Asserts the README contains the deterministic release URL.
- `tests/test_publish.py` (new): covers happy path, missing archive, missing description, missing gh, and gh failure propagation. 5 tests.
- README "Admin flow" emergency-local recipe and "Release internals" updated to describe the new pack → commit → publish ordering.
- Drops the `gh`-installed preflight check from `tools.release` (it no longer needs gh); `tools.publish` keeps its own gh check.

## Test plan

- [x] Full pytest suite passes locally (75/75).
- [x] Diff vs `main` contains only the split — no stray data, no reverts of recently merged PRs.
- [x] `.github/workflows/release.yml` parses as valid YAML.
- [ ] After merge: the next data PR's CI run should produce a release tag whose target commit (visible on the release page on GitHub) is the CI commit-back, not the data-merge commit. Verify on the resulting release page.