### PR TITLE
Add the Mabanga case to Mambasa

### DIFF
--- a/data/insp_sitrep/processed/insp_sitrep__cumulative_suspected_cases__daily.csv
+++ b/data/insp_sitrep/processed/insp_sitrep__cumulative_suspected_cases__daily.csv
@@ -103,6 +103,6 @@ Kalunguta,26/05/2026,2
 Karisimbi,26/05/2026,5
 Damas,26/05/2026,4
 Fataki,26/05/2026,1
-Mambasa,26/05/2026,4
+Mambasa,26/05/2026,5
 Rimba,26/05/2026,14
 Kyondo,26/05/2026,3

--- a/data/insp_sitrep/processed/insp_sitrep__new_suspected_cases__daily.csv
+++ b/data/insp_sitrep/processed/insp_sitrep__new_suspected_cases__daily.csv
@@ -107,6 +107,6 @@ Kalunguta,26/05/2026,2
 Karisimbi,26/05/2026,5
 Damas,26/05/2026,4
 Fataki,26/05/2026,1
-Mambasa,26/05/2026,4
+Mambasa,26/05/2026,5
 Rimba,26/05/2026,14
 Kyondo,26/05/2026,3


### PR DESCRIPTION
## What's new

Updated to allocate a new suspected case from Mabanga (not a healthzone) to the Mambasa healthzone. Team at INRB reviewed and decided this is the most accurate place to put it for now, but let's note that there may also be a place called Mabanga in Mangala


## Contributor checklist

- [x] My PR touches only `data/**`, `tests/**`, and unrelated docs.
- [x] I did NOT commit changes under `build/`, `qa/`, `dist/`, or to the `README.md` "current build" / "past releases" sections.
- [x] `pytest` and `python -m tools.qa` pass locally.
- [x] `data/<dataset>/metadata.yaml` is up to date (`retrieved_on`, source URL, license, contact).
