### PR TITLE
Fixing empty cols writing out to long format

### DIFF
--- a/tests/test_build_geojson_vector.py
+++ b/tests/test_build_geojson_vector.py
@@ -1,0 +1,44 @@
+import csv
+from types import SimpleNamespace
+
+from tools import build_geojson
+
+
+def test_attach_vector_ignores_empty_header(tmp_path, monkeypatch):
+    """
+    Checks that we're not including an empty header col in geoJSON output data if
+    row.names were present from R CSV output
+    """
+    folder = tmp_path / "example"
+    processed = folder / "processed"
+    long_dir = tmp_path / "long"
+    processed.mkdir(parents=True)
+
+    with open(processed / "example__metric__static.csv", "w", encoding="utf-8") as fp:
+        fp.write(",nom,value\n1,Rwampara,42\n")
+
+    monkeypatch.setattr(build_geojson, "LONG_DIR", long_dir)
+    monkeypatch.setattr(build_geojson, "to_canonical", lambda name: name)
+
+    feature = {"properties": {}}
+    attached = build_geojson._attach_vector(
+        folder,
+        "example__metric__static.csv",
+        SimpleNamespace(dataset="example", metric="metric"),
+        {"Rwampara": feature},
+    )
+
+    # Check that things were attached
+    assert attached == 1
+
+    # Check that long data is parsed correctly
+    with open(long_dir / "example__metric.csv", newline="") as fp:
+        reader = csv.DictReader(fp)
+        assert reader.fieldnames is not None
+        assert "" not in reader.fieldnames, "Empty col in long output"
+    
+
+    # Check geo features
+    values = feature["properties"]["example"]["metric"]
+    assert values == {"value": 42}
+    assert "" not in values

--- a/tools/build_geojson.py
+++ b/tools/build_geojson.py
@@ -119,11 +119,10 @@ def _attach_vector(folder: Path, file_name: str, parsed, features_by_nom: dict[s
     src = folder / "processed" / file_name
     with src.open(newline="", encoding="utf-8-sig") as f:
         reader = csv.DictReader(f)
-        fieldnames = reader.fieldnames or []
-        rows = list(reader)
+        rows = [{k: v for k,v in row.items() if k != ""} for row in reader]
+    
+    fieldnames = list(rows[0].keys())
     date_col = next((c for c in DATE_COLUMN_CANDIDATES if c in fieldnames), None)
-    # Skip empty-header columns (R's write.csv row-index artifact) so they
-    # don't end up as stray "" keys in feature properties.
     value_cols = [c for c in fieldnames if c and c != "nom" and c != date_col]
 
     # For time-series: pick latest row per canonical nom.
@@ -159,7 +158,11 @@ def _attach_vector(folder: Path, file_name: str, parsed, features_by_nom: dict[s
     # Long-format copy.
     LONG_DIR.mkdir(parents=True, exist_ok=True)
     dst = LONG_DIR / f"{dataset_token}__{metric}.csv"
-    dst.write_text(src.read_text(encoding="utf-8-sig"), encoding="utf-8")
+
+    with dst.open("w", encoding="utf-8-sig") as fp:
+        writer = csv.DictWriter(fp, fieldnames=fieldnames)
+        writer.writerows(rows)
+
     return attached
 
 


### PR DESCRIPTION
## What's new
- Removes empty col left by row.names=T in R on read in
- Avoids direct copy of file to avoid propogating to long output
- Adds unit test to track regression in both outputs



## Contributor checklist

- [ ] My PR touches only `data/**`, `tests/**`, and unrelated docs.
  - *Adds 1 unit test to test suite and modifies code in tools/*
- [x] I did NOT commit changes under `build/`, `qa/`, `dist/`, or to the `README.md` "current build" / "past releases" sections.
- [x] `pytest` and `python -m tools.qa` pass locally.
- [x] `data/<dataset>/metadata.yaml` is up to date (`retrieved_on`, source URL, license, contact).
