### PR TITLE
Enforcing ISO-8601 Guarantee for vector data from README

### DIFF
--- a/tests/test_qa_vector.py
+++ b/tests/test_qa_vector.py
@@ -1,0 +1,36 @@
+"""Tests for vector QA date validation."""
+
+import csv
+from pathlib import Path
+
+from tools import qa
+from tools.lib.schema import parse_filename
+
+
+def _write_vector(path: Path, rows: list[list[str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows(rows)
+
+
+def test_vector_qa_rejects_non_iso_dates(tmp_path: Path, monkeypatch):
+    p = tmp_path / "test__cases__daily.csv"
+    _write_vector(
+        p,
+        [
+            ["date", "nom", "cases"],
+            ["2026-05-29", "Bunia", "1"],
+            ["05/30/2026", "Goma", "2"],
+        ],
+    )
+    monkeypatch.setattr(
+        qa,
+        "to_canonical",
+        lambda name: name if name in {"Bunia", "Goma"} else None,
+    )
+
+    parsed = parse_filename(p.name)
+    assert parsed is not None
+    result = qa.qa_vector("test", p, parsed)
+
+    assert result.status == "fail"
+    assert any("non-ISO date values" in r for r in result.reasons)

--- a/tools/qa.py
+++ b/tools/qa.py
@@ -168,6 +168,8 @@ def qa_vector(dataset: str, path: Path, parsed) -> FileResult:
     canonical_seen: set[str] = set()
     keys: list = []
     width_mismatches = 0
+    checked_dates: set[str] = set()
+    bad_dates: set[str] = set()
     for ri, r in enumerate(rows, start=2):
         if len(r) != len(header):
             width_mismatches += 1
@@ -178,6 +180,19 @@ def qa_vector(dataset: str, path: Path, parsed) -> FileResult:
         else:
             canonical_seen.add(canonical)
         keys.append((r[nom_i], r[date_i]) if date_i is not None else r[nom_i])
+        if date_i is not None:
+            date_value = r[date_i]
+            if date_value not in checked_dates:
+                checked_dates.add(date_value)
+                if date_col == "year":
+                    if len(date_value) != 4 or not date_value.isdecimal():
+                        bad_dates.add(date_value)
+                else:
+                    try:
+                        if dt.date.fromisoformat(date_value).isoformat() != date_value:
+                            bad_dates.add(date_value)
+                    except ValueError:
+                        bad_dates.add(date_value)
     if width_mismatches:
         reasons.append(f"{width_mismatches} rows with width mismatch (expected {len(header)} fields)")
 
@@ -188,6 +203,11 @@ def qa_vector(dataset: str, path: Path, parsed) -> FileResult:
     dup = [k for k, c in Counter(keys).items() if c > 1]
     if dup:
         reasons.append(f"{len(dup)} duplicate keys (sample: {dup[:3]})")
+    if bad_dates:
+        reasons.append(
+            f"{len(bad_dates)} non-ISO {date_col} values "
+            f"(sample: {sorted(bad_dates)[:5]})"
+        )
 
     fatal = [r for r in reasons if not r.endswith("(warn)")]
     status = "fail" if fatal else ("warn" if reasons else "pass")


### PR DESCRIPTION
## What's new
- Data contract specifies dates must be ISO-8601 compliant, but QA does not check this on load
- Adds QA code to validate years and date stamps in vectors to ensure they're joinable downstream
- Adds a unit-test to check regression


## Contributor checklist

- [ ] My PR touches only `data/**`, `tests/**`, and unrelated docs.
  - _Modifies qa module in tools/_
- [x] I did NOT commit changes under `build/`, `qa/`, `dist/`, or to the `README.md` "current build" / "past releases" sections.
- [ ] `pytest` and `python -m tools.qa` pass locally.
  - **FAIL because current INSP data on main are out of spec per the data contract.**
- [x] `data/<dataset>/metadata.yaml` is up to date (`retrieved_on`, source URL, license, contact).
