### PR TITLE
Create folder for archived WHO reports

### DIFF
--- a/data/archive/README.md
+++ b/data/archive/README.md
@@ -1,0 +1,80 @@
+# Archived WHO situation reports
+
+Public **WHO Weekly External Situation Reports** on the 2026 Bundibugyo Ebola virus outbreak in the Democratic Republic of the Congo (DRC), stored as untouched PDFs under `raw/`.
+
+This folder is where we keep relevant, publicly facing documents for posterity, even if they are not explicitly integrated into the GeoJSON build or part of a dataset we are tracking. There is **no** `process.py`, **no** `processed/` directory, and **no** QA contract outputs — only archived source PDFs.
+
+Digitised case and death tables appear separately when extracted for the map build; this folder preserves the original reports as published.
+
+------------------------------------------------------------------------
+
+## Files
+
+| File | Description |
+|----|----|
+| `raw/WHO_Wk_Ext_SitRep*.pdf` | Untouched WHO weekly external situation report PDFs |
+| `metadata.yaml` | Provenance, licence, and archive notes |
+
+**No `processed/` outputs** — see **Data quality and limitations** and `metadata.yaml`.
+
+------------------------------------------------------------------------
+
+## Raw documents
+
+**Source:** [World Health Organization](https://www.who.int) — Weekly External Situation Reports on the 2026 Bundibugyo Ebola virus outbreak in DRC.
+
+**Coverage (current archive):**
+
+| File | Report | Data as of |
+|----|----|----|
+| `raw/WHO_Wk_Ext_SitRep01_18_05_2026.pdf` | SitRep 01 | 2026-05-18 |
+| `raw/WHO_Wk_Ext_SitRep02_24_05_2026.pdf` | SitRep 02 | 2026-05-24 |
+| `raw/WHO_Wk_Ext_SitRep03_31_05_2026.pdf` | SitRep 03 | 2026-05-31 |
+| `raw/WHO_Wk_Ext_SitRep04_07_06_2026.pdf` | SitRep 04 | 2026-06-07 |
+
+**Naming convention:** `WHO_Wk_Ext_SitRep<NN>_<DD>_<MM>_<YYYY>.pdf` — report number and the sitrep “data as of” date.
+
+------------------------------------------------------------------------
+
+## Method (current state)
+
+1. **Download** — Obtain the published PDF from WHO when a new weekly external sitrep is released.
+2. **Store** — Place the untouched file under `raw/` using the naming convention above.
+3. **Update metadata** — Adjust `metadata.yaml` (`retrieved_on`, file list in `notes`) when adding reports.
+
+There is no downstream processing in this folder.
+
+**What this is not**
+
+- Not a tracked dataset with contract-shaped CSV outputs.
+- Not merged into `build/drc_health_zones.geojson`.
+- Not a substitute for [`data/epi/`](../epi/) or [`data/insp_sitrep/`](../insp_sitrep/) where outbreak indicators are digitised for analysis.
+
+------------------------------------------------------------------------
+
+## Regenerating outputs
+
+There is **no** `process.py` in this folder and no processed outputs to regenerate. To refresh the archive:
+
+1. Download new or updated WHO weekly external sitrep PDFs.
+2. Add them under `raw/` and update `metadata.yaml`.
+
+------------------------------------------------------------------------
+
+## Data quality and limitations
+
+| Issue | Detail |
+|----|----|
+| **Archive only** | PDFs are stored for reference; contents are not automatically parsed or validated here. |
+| **Not in build** | `metadata.yaml` sets `status: archive`; root and [`data/README.md`](../README.md) list this folder as outside the GeoJSON pipeline. |
+| **Licence** | WHO open access. Reuse with attribution per [WHO copyright policy](https://www.who.int/about/policies/publishing/copyright). |
+
+------------------------------------------------------------------------
+
+## Provenance
+
+- **Provider:** [World Health Organization](https://www.who.int)
+- **Raw files:** `raw/WHO_Wk_Ext_SitRep*.pdf`
+- **Metadata:** `metadata.yaml`
+
+For project-wide data conventions, see [`data/README.md`](../README.md).

--- a/data/archive/metadata.yaml
+++ b/data/archive/metadata.yaml
@@ -1,0 +1,14 @@
+source: "World Health Organization — Weekly External Situation Reports (2026 Bundibugyo Ebola virus outbreak, DRC)"
+citation: "World Health Organization. Bundibugyo Ebola virus outbreak, Democratic Republic of the Congo: Weekly External Situation Reports (SitRep 01–04, May–June 2026)."
+source_url: "https://www.who.int"
+retrieved_on: "2026-06-07"
+license: "WHO open access. Reuse with attribution per https://www.who.int/about/policies/publishing/copyright"
+contact: "outbreak@who.int"
+runtime: none
+status: archive
+notes: |
+  Archive of publicly facing WHO weekly external situation report PDFs in raw/.
+  No process.py and no processed/ outputs — documents are kept for posterity only
+  and are not integrated into the GeoJSON build or QA contract pipeline.
+  Current files: WHO_Wk_Ext_SitRep01_18_05_2026.pdf through
+  WHO_Wk_Ext_SitRep04_07_06_2026.pdf.

--- a/data/archive/raw/WHO_Wk_Ext_SitRep01_18_05_2026.pdf
+++ b/data/archive/raw/WHO_Wk_Ext_SitRep01_18_05_2026.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b43fc698bf2407323c6d6af25a3679eccdd2d68b3effc61a7563e6ef977366ba
+size 757033

--- a/data/archive/raw/WHO_Wk_Ext_SitRep02_24_05_2026.pdf
+++ b/data/archive/raw/WHO_Wk_Ext_SitRep02_24_05_2026.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3380451e235fde7601414d44d01c8c00a702d85d8d122949be5dae013d0a235f
+size 902854

--- a/data/archive/raw/WHO_Wk_Ext_SitRep03_31_05_2026.pdf
+++ b/data/archive/raw/WHO_Wk_Ext_SitRep03_31_05_2026.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b03806379424fe30d0166b362978e3667d5e12e995bcafbb55e89ba1c075ca7e
+size 922196

--- a/data/archive/raw/WHO_Wk_Ext_SitRep04_07_06_2026.pdf
+++ b/data/archive/raw/WHO_Wk_Ext_SitRep04_07_06_2026.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e20262c9e8e318db5c9e1d49327c4bb5a45c6bf7eb50af19ab54baa2600ebc75
+size 911608


### PR DESCRIPTION
… files

## What's new

<!-- This section becomes the GitHub Release description and the README "what's new" block. -->
<!-- Write 1–3 sentences describing what changed in this PR from a data/consumer perspective. -->
<!-- The first line is used as the short summary in the README "Past releases" table. -->

- Create a folder for archived weekly WHO reports (unprocessed) to serve as a digital record
- Create corresponding readme and .yaml files to describe these reports and their status as unprocessed records



## Contributor checklist

- [X] My PR touches only `data/**`, `tests/**`, and unrelated docs.
- [X] I did NOT commit changes under `build/`, `qa/`, `dist/`, or to the `README.md` "current build" / "past releases" sections.
- [X] `pytest` and `python -m tools.qa` pass locally.
- [X] `data/<dataset>/metadata.yaml` is up to date (`retrieved_on`, source URL, license, contact).
